### PR TITLE
enable native deep-cover HTML report

### DIFF
--- a/.deep_cover.rb
+++ b/.deep_cover.rb
@@ -1,0 +1,12 @@
+DeepCover.configure do
+  output 'coverage/report-deep-cover'
+  paths %w(./lib)
+  #reporter :istanbul
+end
+
+autoload :Sass, 'sass'
+class DeepCover::Reporter::HTML::Site
+  def compile_stylesheet source, dest
+    IO.write dest, (Sass::Engine.for_file source, style: :compressed).to_css
+  end
+end

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.bundle/
+/.sass-cache/
 /Gemfile.lock
-/build/
+/coverage/
+/deep_cover/
 /pkg/

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,4 @@
+SimpleCov.start do
+  add_filter %w(/.bundle/ /spec/)
+  coverage_dir 'coverage/report-simplecov'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'deep-cover', git: 'https://github.com/mojavelinux/deep-cover', branch: 'no-cli', require: false
+group :coverage do
+  gem 'deep-cover', git: 'https://github.com/mojavelinux/deep-cover', branch: 'no-cli', require: false
+  gem 'sass', require: false
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-if ENV['COVERAGE'] == 'true'
+case ENV['COVERAGE']
+when 'deep'
+  ENV['DEEP_COVER'] = 'true'
+  require 'deep_cover'
+when 'true'
   require 'deep_cover/builtin_takeover'
   require 'simplecov'
-  SimpleCov.start do
-    add_filter %w(/.bundle/ /spec/)
-    coverage_dir 'build/coverage-report'
-  end
 end
 
 require 'kramdown-asciidoc'


### PR DESCRIPTION
- add sass dependency for deep-cover
- patch deep-cover to compile sass
- group coverage dependencies
- move simplecov config to .simplecov
- add deep-cover config at .deep-cover.rb
- simplify how coverage tools are loaded
- use native deep-cover HTML report when COVERAGE=deep
- move coverage reports to coverage folder
- ignore generated files