### PR TITLE
resolves #31 add public API to convert string or file path 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 === Added
 
+* add a public API (Kramdoc.convert and Kramdoc.convert_file) for converting input strings and paths, respectively (#31)
+* update CLI to use public API (#31)
 * run test suite on Windows using AppVeyor (#32)
 * don't crash when empty comment occurs under primary text of list item
 * convert phrase enclosed in <span> (#36)

--- a/lib/kramdown-asciidoc.rb
+++ b/lib/kramdown-asciidoc.rb
@@ -1,14 +1,8 @@
 require 'kramdown'
+require_relative 'kramdown-asciidoc/kramdown_ext/parser/html'
 require_relative 'kramdown-asciidoc/core_ext/regexp/is_match'
+require_relative 'kramdown-asciidoc/api'
 require_relative 'kramdown-asciidoc/converter'
 require_relative 'kramdown-asciidoc/writer'
+autoload :Pathname, 'pathname'
 autoload :YAML, 'yaml'
-
-class Kramdown::Parser::Html::ElementConverter
-  def convert_br el
-    el.options.replace location: el.options[:location], html_tag: true
-    el.type = el.value.to_sym
-    el.value = nil
-    nil
-  end
-end

--- a/lib/kramdown-asciidoc/api.rb
+++ b/lib/kramdown-asciidoc/api.rb
@@ -1,0 +1,27 @@
+module Kramdown; module AsciiDoc
+  LF = ?\n
+
+  def self.convert markdown, opts = {}
+    markdown = markdown.rstrip
+    markdown = markdown.slice 1, markdown.length while markdown.start_with? LF
+    attributes = (opts[:attributes] ||= {})
+    markdown = ::Kramdown::AsciiDoc.extract_front_matter markdown, attributes
+    markdown = ::Kramdown::AsciiDoc.replace_toc markdown, attributes
+    asciidoc = (::Kramdown::Document.new markdown, (::Kramdown::AsciiDoc::DEFAULT_PARSER_OPTS.merge opts)).to_asciidoc
+    asciidoc += LF unless asciidoc.empty?
+    if (to = opts[:to])
+      (to.respond_to? :write) ? (to.write asciidoc) : (::IO.write to, asciidoc)
+      nil
+    else
+      asciidoc
+    end
+  end
+
+  def self.convert_file markdown_file, opts = {}
+    markdown = ::IO.read markdown_file, mode: 'r:UTF-8', newline: :universal
+    (output_file = (::Pathname.new markdown_file).sub_ext '.adoc').dirname.mkpath
+    convert markdown, (opts.merge to: output_file)
+  end
+end; end
+
+Kramdoc = Kramdown::AsciiDoc

--- a/lib/kramdown-asciidoc/kramdown_ext/parser/html.rb
+++ b/lib/kramdown-asciidoc/kramdown_ext/parser/html.rb
@@ -1,0 +1,9 @@
+class Kramdown::Parser::Html::ElementConverter
+  # Overload convert_br to add the :html_tag option to indicate this br element originates from an HTML tag
+  def convert_br el
+    el.options.replace location: el.options[:location], html_tag: true
+    el.type = el.value.to_sym
+    el.value = nil
+    nil
+  end
+end

--- a/lib/kramdown-asciidoc/writer.rb
+++ b/lib/kramdown-asciidoc/writer.rb
@@ -125,7 +125,7 @@ module Kramdown; module AsciiDoc
     end
 
     def to_s
-      ((@header.empty? ? @body : (@header + (@body.empty? ? [] : ['']) + @body)).join LF) + LF
+      (@header.empty? ? @body : (@header + (@body.empty? ? [] : [''] + @body))).join LF
     end
   end
 end; end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,0 +1,63 @@
+require_relative 'spec_helper'
+
+describe Kramdown::AsciiDoc do
+  context '#convert' do
+    it 'converts Markdown to AsciiDoc' do
+      input = <<~EOS
+      ---
+      title: Document Title
+      ---
+
+      Body content.
+      EOS
+
+      expected = <<~EOS
+      = Document Title
+
+      Body content.
+      EOS
+
+      (expect subject.convert input).to eql expected
+    end
+
+    it 'writes AsciiDoc to filename specified in :to option' do
+      the_output_file = output_file 'convert-api.adoc'
+      (expect subject.convert 'Converted using the API', to: the_output_file).to be_nil
+      (expect (IO.read the_output_file)).to eql %(Converted using the API\n)
+    end
+
+    it 'writes AsciiDoc to IO object specified in :to option' do
+      old_stdout, $stdout = $stdout, StringIO.new
+      begin
+        (expect subject.convert 'text', to: $stdout).to be_nil
+        (expect $stdout.string).to eql %(text\n)
+      ensure
+        $stdout = old_stdout
+      end
+    end
+
+    it 'adds line feed (EOL) to end of output document if non-empty' do
+      (expect subject.convert 'paragraph').to end_with ?\n
+    end
+
+    it 'does not add line feed (EOL) to end of output document if empty' do
+      (expect subject.convert '').to be_empty
+    end
+  end
+
+  context '#convert_file' do
+    it 'converts Markdown file to AsciiDoc file' do
+      the_source_file = output_file 'convert-file-api.md'
+      the_output_file = output_file 'convert-file-api.adoc'
+      IO.write the_source_file, 'Converted using the API'
+      (expect subject.convert_file the_source_file).to be_nil
+      (expect (IO.read the_output_file)).to eql %(Converted using the API\n)
+    end
+  end
+end
+
+describe Kramdoc do
+  it 'supports Kramdoc as an alias for Kramdown::AsciiDoc' do
+    (expect Kramdoc).to eql Kramdown::AsciiDoc
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,6 +1,5 @@
 require_relative 'spec_helper'
 require 'kramdown-asciidoc/cli'
-require 'stringio'
 
 describe Kramdown::AsciiDoc::Cli do
   subject { Kramdown::AsciiDoc::Cli }

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -9,9 +9,9 @@ describe Kramdown::AsciiDoc::Converter do
   context '#convert' do
     let (:input) { %(# Document Title\n\nBody text.) }
 
-    it 'adds line feed (EOL) to end of output document' do
-      (expect converter.convert root).to end_with %(\n)
-      (expect doc.to_asciidoc).to end_with %(\n)
+    it 'does not add line feed (EOL) to end of output document' do
+      (expect converter.convert root).not_to end_with ?\n
+      (expect doc.to_asciidoc).not_to end_with ?\n
     end
 
     # Q: can we find a scenario that covers this?
@@ -154,7 +154,7 @@ describe Kramdown::AsciiDoc::Converter do
       When using this technology, anything is possible.
       EOS
 
-      expected = <<~EOS
+      expected = <<~EOS.chomp
       = Introduction
       :description: An introduction to this amazing technology.
 
@@ -177,7 +177,7 @@ describe Kramdown::AsciiDoc::Converter do
       When using this technology, anything is possible.
       EOS
 
-      expected = <<~EOS
+      expected = <<~EOS.chomp
       = Introduction
       :description: An introduction to this amazing technology.
 

--- a/spec/scenario_spec.rb
+++ b/spec/scenario_spec.rb
@@ -15,7 +15,7 @@ describe 'scenario' do
       context %(for #{scenario_name}) do
         let(:input) { IO.read input_filename, mode: 'r:UTF-8', newline: :universal }
         let(:extra_options) { options }
-        let(:expected) { IO.read output_filename, mode: 'r:UTF-8', newline: :universal }
+        let(:expected) { (IO.read output_filename, mode: 'r:UTF-8', newline: :universal).chomp }
         it 'converts Markdown to AsciiDoc' do
           (expect doc.to_asciidoc).to eql expected
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ end
 
 require 'kramdown-asciidoc'
 require 'fileutils'
+autoload :StringIO, 'stringio'
 
 RSpec.configure do |config|
   config.after :suite do


### PR DESCRIPTION
- add Kramdown::AsciiDoc.convert to convert a string
- add Kramdown::AsciiDoc.convert_file to convert a file path
- alias Kramdown::AsciiDoc to Kramdoc for convenience and to align with name of CLI
- update CLI to use public API
- use write instead of puts to write lines to stdio
- only add trailing newline to AsciiDoc output in public API
- move kramdown patch under kramdown_ext folder
- convert pathname to autoload when Pathname is accessed