### PR TITLE
consolidate logic in CLI

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,12 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * IO object can be used as value of :to option in `convert` and `convert_file` (#43)
 * intermediate directories are now created in `convert` instead of `convert_file` (#45)
 * `convert_file` now writes output file using explicit UTF-8 encoding (#46)
+* prevent `convert_file` from using input file as implicit output file
 * allow library to be required via alias `kramdoc`
+
+=== Changed
+
+* consolidated logic in CLI by further delegating to API
 
 == 1.0.0.alpha.11 (2018-08-02) - @mojavelinux
 

--- a/lib/kramdown-asciidoc/api.rb
+++ b/lib/kramdown-asciidoc/api.rb
@@ -33,7 +33,10 @@ module Kramdown; module AsciiDoc
     if (to = opts[:to])
       to = ::Pathname.new to.to_s unless ::Pathname === to || (to.respond_to? :write)
     else
-      to = (::Pathname.new markdown_file).sub_ext '.adoc' unless opts.key? :to
+      unless opts.key? :to
+        to = (::Pathname.new markdown_file).sub_ext '.adoc'
+        raise ::IOError, %(input and output cannot be the same file: #{markdown_file}) if to.to_s == markdown_file.to_s
+      end
     end
     convert markdown, (opts.merge to: to, encode: false)
   end


### PR DESCRIPTION
- consolidated logic in CLI by further delegating to API
- prevent `convert_file` from using input file as implicit output file
- coerce arguments to Cli.run to array
- add additional tests to cover cases when input comes from stdin
- redirect stdin for CLI tests
- simplify CLI exit values
