### PR TITLE
Add converter for block LaTeX

### DIFF
--- a/lib/kramdown-asciidoc/converter.rb
+++ b/lib/kramdown-asciidoc/converter.rb
@@ -461,6 +461,13 @@ module Kramdown; module AsciiDoc
       opts[:writer].append %(#{mark}#{composed_text}#{mark})
     end
 
+    def convert_math el, opts
+      composed_text = el.value
+      mark_left = "\n[latexmath]\n++++\n"
+      mark_right = "\n++++\n"
+      opts[:writer].append %(#{mark_left}#{composed_text}#{mark_right})
+    end
+
     def convert_strong el, opts
       if ((composed_text = compose_text el).include? ' > ') && MenuRefRx =~ composed_text
         @attributes['experimental'] = ''

--- a/lib/kramdown-asciidoc/converter.rb
+++ b/lib/kramdown-asciidoc/converter.rb
@@ -463,8 +463,8 @@ module Kramdown; module AsciiDoc
 
     def convert_math el, opts
       composed_text = el.value
-      mark_left = "\n[latexmath]\n++++\n"
-      mark_right = "\n++++\n"
+      mark_left = "\n[latexmath]\n++++\n\\(\n"
+      mark_right = "\n\\)\n++++\n"
       opts[:writer].append %(#{mark_left}#{composed_text}#{mark_right})
     end
 


### PR DESCRIPTION
This PR adds the ability to convert block LaTeX embedded in markdown files (delimited by `$$` on both left and right sides) into a passthrough block with the `latexmath` macro. [methods.co](https://www.methods.co.nz/asciidoc/chunked/ch25.html) has an example.

This also prevents kramdoc from throwing an error when it sees `$$..$$` in an input markdown file. Normally, this would result in the following error:

```
undefined method `convert_math' for #<Kramdown::AsciiDoc::Converter:0x00007fdc8f072c18> (NoMethodError)
```