### PR TITLE
Correctly handle GFM checkbox syntax

### DIFF
--- a/lib/kramdown-asciidoc/converter.rb
+++ b/lib/kramdown-asciidoc/converter.rb
@@ -575,6 +575,14 @@ module AsciiDoc
         opts[:writer].append %(^#{contents}^)
       when 'sub'
         opts[:writer].append %(~#{contents}~)
+      when 'input'                                                              
+        if el.attr['type'] == 'checkbox'                                        
+          if el.attr['checked']                                                 
+            opts[:writer].append '[x] '                                         
+          else                                                                  
+            opts[:writer].append '[ ] '                                                                                                                                                                        
+          end                                                                   
+        end  
       else
         attrs = (attrs = el.attr).empty? ? '' : attrs.map {|k, v| %( #{k}="#{v}") }.join
         opts[:writer].append %(+++<#{tag}#{attrs}>+++#{contents}+++</#{tag}>+++)


### PR DESCRIPTION
GFM checkbox notation wasn't managed by the tool and generate ugly html tag
inside the asciidoc document which then make parsing errors occurs when attempting
to make a pdf document from that.

This is a naive and quicly writen patch, I've never developped using ruby.