### PR TITLE
resolves #122 update rexml version to address various CVE

### DIFF
--- a/kramdown-asciidoc.gemspec
+++ b/kramdown-asciidoc.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/asciidoctor/kramdown-asciidoc/issues',
     'changelog_uri' => 'https://github.com/asciidoctor/kramdown-asciidoc/blob/master/CHANGELOG.adoc',
     'mailing_list_uri' => 'http://discuss.asciidoctor.org',
-    'source_code_uri' => 'https://github.com/asciidoctor/kramdown-asciidoc'
+    'source_code_uri' => 'https://github.com/asciidoctor/kramdown-asciidoc',
   }
   # NOTE required ruby version is informational only; it's not enforced since it can't be overridden and can cause builds to break
   #s.required_ruby_version = '>= 2.3.0'
@@ -32,8 +32,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'kramdown', '~> 2.4.0'
-  s.add_runtime_dependency 'rexml', '~> 3.2.0'
   s.add_runtime_dependency 'kramdown-parser-gfm', '~> 1.1.0'
+  s.add_runtime_dependency 'rexml', '~> 3.4.2'
 
   s.add_development_dependency 'rake', '~> 13.0.0'
   s.add_development_dependency 'rspec', '~> 3.11.0'


### PR DESCRIPTION
This addresses the following CVE's found by `bundle-audit`

```
Name: rexml
Version: 3.2.9
CVE: CVE-2024-39908
GHSA: GHSA-4xqq-m2hx-25v8
Criticality: Medium
URL: https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8
Title: DoS in REXML
Solution: update to '>= 3.3.2'

Name: rexml
Version: 3.2.9
CVE: CVE-2024-41123
GHSA: GHSA-r55c-59qm-vjw6
Criticality: Medium
URL: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123
Title: DoS vulnerabilities in REXML
Solution: update to '>= 3.3.3'

Name: rexml
Version: 3.2.9
CVE: CVE-2024-41946
GHSA: GHSA-5866-49gr-22v4
Criticality: Medium
URL: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946
Title: DoS vulnerabilities in REXML
Solution: update to '>= 3.3.3'

Name: rexml
Version: 3.2.9
CVE: CVE-2024-43398
GHSA: GHSA-vmwr-mc7x-5vc3
Criticality: Medium
URL: https://github.com/ruby/rexml/security/advisories/GHSA-vmwr-mc7x-5vc3
Title: REXML denial of service vulnerability
Solution: update to '>= 3.3.6'

Name: rexml
Version: 3.2.9
CVE: CVE-2024-49761
GHSA: GHSA-2rxp-v6pw-ch6m
Criticality: High
URL: https://github.com/ruby/rexml/security/advisories/GHSA-2rxp-v6pw-ch6m
Title: REXML ReDoS vulnerability
Solution: update to '>= 3.3.9'
```

I updated to the most recent version of [rexml](https://rubygems.org/gems/rexml/) and ran the specs which were the acceptance criteria laid out in [this issue](https://github.com/asciidoctor/kramdown-asciidoc/issues/122)